### PR TITLE
note.mdを更新し、クラス設計のルールとabstract classの使用方法に関する詳細を追加

### DIFF
--- a/note.md
+++ b/note.md
@@ -1,4 +1,6 @@
-# クラス設計のルール
+# クラスについて
+
+## 今回のクラス設計
 1. 単一責任の原則:
 - `NetworkGenerator`: ネットワーク生成のみを担当
 - `NetworkAnalyzer`: 分析とプロットを担当
@@ -14,3 +16,64 @@
 4. 拡張性:
 - 新しい分析手法の追加が容易
 - 新しいネットワークタイプの追加が容易
+
+## abstract classのメモ
+- `abstractmethod`: Pythonのabc(Abstract Base Class)モジュールで提供されるデコレータ
+
+1. 目的
+- 抽象メソッドを定義するために使用
+- サブクラスで実装しなければならないメソッドを指定
+- サブクラスで実装されていない場合、インスタンス化を防ぐ
+
+2. 使用方法
+```python
+from abc import ABC, abstractmethod
+
+class NetworkGenerator(ABC):
+    @abstractmethod
+    def generate(self) -> nx.Graph:
+        pass
+```
+
+3. 効果
+- このデコレータが付いたメソッドを持つクラスは、直接インスタンス化できない
+- サブクラスは必ずこのメソッド(今回なら`generate()`)を実装する必要がある
+- 実装忘れがある場合、インスタンス化時に TypeError が発生
+- これにより、ネットワーク生成の基本インターフェースを強制し、一貫性のある設計を実現
+
+4. 具体例
+```python
+# ✅ 正しい実装
+class SmallWorldNetwork(NetworkGenerator):
+    def generate(self) -> nx.Graph:  # abstractmethodを実装
+        # 実装内容
+        return graph
+
+# ❌ エラーになる実装
+class BadNetwork(NetworkGenerator):
+    pass  # generateメソッドを実装していないのでエラー
+```
+
+# ソースコード部分について
+
+## クラスで実装した抽象メソッドを呼び出す流れ
+1. クラス階層の階層
+- `NetworkGenerator`: 抽象基底クラス（インターフェース）
+- `SmallWorldNetwork`: 具体的な実装を持つ子クラス
+
+2. `abstractmethod`と使用例の関係
+- NetworkGeneratorは抽象クラスなので直接インスタンス化できない
+- `@abstractmethod`が付いたメソッドは実装を持たない
+- 実際の使用時は必ず具体的な実装を持つ子クラス（この場合`SmallWorldNetwork`）を使用する
+
+e.g.
+```python
+# ❌ これはエラーになる
+generator = NetworkGenerator()  # 抽象クラスはインスタンス化できない
+
+# ✅ これが正しい使用方法
+generator = SmallWorldNetwork(n_nodes=100, k_neighbors=4)  # 具体的な実装を持つ子クラスを使用
+```
+
+>[!NOTE]
+> オブジェクト指向設計の基本原則の一つで、具体的な実装は子クラスで行い、親クラスはインターフェースの定義のみを行うという考え方に基づいている!!


### PR DESCRIPTION
This pull request includes updates to the `note.md` file to improve the documentation on class design principles and abstract classes in Python. The changes include renaming a section, adding a new section on abstract classes, and providing detailed examples and notes.

Updates to class design documentation:

* [`note.md`](diffhunk://#diff-1188c3be78790ea66821b418d8c34e47cb3da9e6367735c64d9b9a9edc010508L1-R3): Renamed the section title from "クラス設計のルール" to "クラスについて" and added a new subsection "今回のクラス設計" to outline the principles of single responsibility and extensibility.

New section on abstract classes:

* [`note.md`](diffhunk://#diff-1188c3be78790ea66821b418d8c34e47cb3da9e6367735c64d9b9a9edc010508R19-R79): Added a comprehensive section on abstract classes, including the purpose and usage of the `abstractmethod` decorator from Python's `abc` module, detailed examples of correct and incorrect implementations, and notes on object-oriented design principles.